### PR TITLE
macOS: native traffic lights, hide-to-tray on close, Cmd+W

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,7 +43,7 @@ void main() async {
     center: true,
     skipTaskbar: false,
     titleBarStyle: TitleBarStyle.hidden,
-    windowButtonVisibility: false,
+    windowButtonVisibility: Platform.isMacOS,
   );
 
   if (Platform.isWindows || Platform.isMacOS) {

--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -88,22 +88,16 @@ class _MainScreenState extends ConsumerState<MainScreen>
   @override
   void onWindowEvent(String eventName) async {
     if (eventName == kWindowEventClose) {
-      await AppUtils.onAppCloseRequested(ref, context);
+      if (Platform.isMacOS) {
+        await windowManager.hide();
+        await TrayUtils.initTray(ref, context);
+      } else {
+        await AppUtils.onAppCloseRequested(ref, context);
+      }
     }
 
     if (eventName == kWindowEventResize) {
       await windowManager.setMinimumSize(const Size(500, 600));
-    }
-
-    if (Platform.isMacOS) {
-      if (eventName == kWindowEventEnterFullScreen) {
-        await windowManager.setTitleBarStyle(TitleBarStyle.normal);
-      }
-
-      if (eventName == kWindowEventLeaveFullScreen) {
-        await windowManager.setTitleBarStyle(TitleBarStyle.hidden,
-            windowButtonVisibility: false);
-      }
     }
 
     super.onWindowEvent(eventName);

--- a/lib/screens/4.settings_tab/widgets/behaviour_section.dart
+++ b/lib/screens/4.settings_tab/widgets/behaviour_section.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:awesome_extensions/awesome_extensions_dart.dart';
 import 'package:flutter/material.dart' show InkWell;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -88,37 +90,39 @@ class _BehaviourSectionState extends ConsumerState<BehaviourSection> {
             ),
           ),
         ),
-        const Divider(),
-        PgListTile(
-          title: el.settingsLoc.behavior.minimize.label,
-          trailing: ConstrainedBox(
-            constraints: const BoxConstraints(
-                minWidth: 180, maxWidth: 180, minHeight: 30),
-            child: Select(
-              filled: true,
-              value: minimizeDD(context)
-                  .firstWhere((act) => act.$1 == behaviour.minimizeAction),
-              onChanged: (act) async {
-                ref
-                    .read(settingsProvider.notifier)
-                    .changeMinimizeBehaviour(act!.$1);
+        if (!Platform.isMacOS) ...[
+          const Divider(),
+          PgListTile(
+            title: el.settingsLoc.behavior.minimize.label,
+            trailing: ConstrainedBox(
+              constraints: const BoxConstraints(
+                  minWidth: 180, maxWidth: 180, minHeight: 30),
+              child: Select(
+                filled: true,
+                value: minimizeDD(context)
+                    .firstWhere((act) => act.$1 == behaviour.minimizeAction),
+                onChanged: (act) async {
+                  ref
+                      .read(settingsProvider.notifier)
+                      .changeMinimizeBehaviour(act!.$1);
 
-                await Db.saveAppSettings(ref.read(settingsProvider));
-              },
-              itemBuilder: (context, value) => OverflowMarquee(
-                  duration: 5.seconds,
-                  delayDuration: 1.seconds,
-                  child: Text(value.$2)),
-              popup: SelectPopup(
-                items: SelectItemList(
-                    children: minimizeDD(context)
-                        .map((act) =>
-                            SelectItemButton(value: act, child: Text(act.$2)))
-                        .toList()),
-              ).call,
+                  await Db.saveAppSettings(ref.read(settingsProvider));
+                },
+                itemBuilder: (context, value) => OverflowMarquee(
+                    duration: 5.seconds,
+                    delayDuration: 1.seconds,
+                    child: Text(value.$2)),
+                popup: SelectPopup(
+                  items: SelectItemList(
+                      children: minimizeDD(context)
+                          .map((act) =>
+                              SelectItemButton(value: act, child: Text(act.$2)))
+                          .toList()),
+                ).call,
+              ),
             ),
           ),
-        ),
+        ],
         const Divider(),
         Column(
           children: [

--- a/lib/widgets/navigation_shell.dart
+++ b/lib/widgets/navigation_shell.dart
@@ -96,10 +96,7 @@ class TitleBar extends ConsumerWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          if (Platform.isMacOS) ...[
-            TitleBarButton(),
-            VerticalDivider(indent: 16, endIndent: 16),
-          ],
+          if (Platform.isMacOS) Gap(70),
           Expanded(
             child: DragToMoveArea(
               child: Row(

--- a/lib/widgets/title_bar_button.dart
+++ b/lib/widgets/title_bar_button.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:scrcpygui/utils/app_utils.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
@@ -24,7 +22,8 @@ class TitleBarButton extends ConsumerWidget {
       IconButton(
         variance: ButtonVariance.ghost,
         size: ButtonSize.small,
-        icon: const Padding(padding: EdgeInsets.all(4.0), child: Icon(Icons.square_outlined)),
+        icon: const Padding(
+            padding: EdgeInsets.all(4.0), child: Icon(Icons.square_outlined)),
         onPressed: () {
           AppUtils.onAppMaximizeRequested();
         },
@@ -32,70 +31,16 @@ class TitleBarButton extends ConsumerWidget {
       IconButton(
         variance: ButtonVariance.ghost,
         size: ButtonSize.small,
-        icon: const Padding(padding: EdgeInsets.all(4.0), child: Icon(Icons.close)),
+        icon: const Padding(
+            padding: EdgeInsets.all(4.0), child: Icon(Icons.close)),
         onPressed: () {
           AppUtils.onAppCloseRequested(ref, context);
-        },
-      ),
-    ];
-
-    final buttonsMac = [
-      Gap(8),
-      IconButton(
-        variance: ButtonVariance.ghost,
-        size: ButtonSize.small,
-        icon: Container(
-          height: 12,
-          width: 12,
-          decoration: BoxDecoration(color: Colors.red, shape: BoxShape.circle),
-          child: Center(
-              child: Icon(
-            Icons.close_rounded,
-            color: Colors.black.withAlpha(50),
-          ).iconX2Small()),
-        ),
-        onPressed: () {
-          AppUtils.onAppCloseRequested(ref, context);
-        },
-      ),
-      IconButton(
-        variance: ButtonVariance.ghost,
-        size: ButtonSize.small,
-        icon: Container(
-          height: 12,
-          width: 12,
-          decoration: BoxDecoration(color: Colors.yellow, shape: BoxShape.circle),
-          child: Center(
-              child: Icon(
-            Icons.remove_rounded,
-            color: Colors.black.withAlpha(50),
-          ).iconX2Small()),
-        ),
-        onPressed: () {
-          AppUtils.onAppMinimizeRequested(ref, context);
-        },
-      ),
-      IconButton(
-        variance: ButtonVariance.ghost,
-        size: ButtonSize.small,
-        icon: Container(
-          height: 12,
-          width: 12,
-          decoration: BoxDecoration(color: Colors.green, shape: BoxShape.circle),
-          child: Center(
-              child: Icon(
-            Icons.add_rounded,
-            color: Colors.black.withAlpha(50),
-          ).iconX2Small()),
-        ),
-        onPressed: () {
-          AppUtils.onAppMaximizeRequested();
         },
       ),
     ];
 
     return Row(
-      children: Platform.isMacOS ? buttonsMac : buttons,
+      children: buttons,
     );
   }
 }

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -7,6 +7,18 @@ class AppDelegate: FlutterAppDelegate {
     return false
   }
 
+  override func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+    if !flag {
+      for window in sender.windows {
+        if !window.isVisible {
+          window.makeKeyAndOrderFront(self)
+          break
+        }
+      }
+    }
+    return true
+  }
+
   override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return true
   }

--- a/macos/Runner/Base.lproj/MainMenu.xib
+++ b/macos/Runner/Base.lproj/MainMenu.xib
@@ -285,19 +285,6 @@
                         </items>
                     </menu>
                 </menuItem>
-                <menuItem title="View" id="H8h-7b-M4v">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <menu key="submenu" title="View" id="HyV-fh-RgO">
-                        <items>
-                            <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
-                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
-                                <connections>
-                                    <action selector="toggleFullScreen:" target="-1" id="dU3-MA-1Rq"/>
-                                </connections>
-                            </menuItem>
-                        </items>
-                    </menu>
-                </menuItem>
                 <menuItem title="Window" id="aUF-d1-5bR">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
@@ -314,6 +301,12 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
+                            <menuItem title="Close Window" keyEquivalent="w" id="DVo-aG-piG">
+                                <connections>
+                                    <action selector="performClose:" target="-1" id="HJg-9M-RAC"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="xCK-dM-YcP"/>
                             <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -2,6 +2,8 @@ import Cocoa
 import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
+  private let customTitleBarHeight: CGFloat = 45.0
+
   override func awakeFromNib() {
     let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
@@ -11,5 +13,36 @@ class MainFlutterWindow: NSWindow {
     RegisterGeneratedPlugins(registry: flutterViewController)
 
     super.awakeFromNib()
+
+    self.collectionBehavior.remove(.fullScreenPrimary)
+    self.collectionBehavior.remove(.fullScreenAuxiliary)
+    self.collectionBehavior.insert(.fullScreenNone)
+    self.collectionBehavior.insert(.fullScreenDisallowsTiling)
+  }
+
+  override func layoutIfNeeded() {
+    super.layoutIfNeeded()
+    repositionTrafficLights()
+  }
+
+  private func repositionTrafficLights() {
+    let xStart: CGFloat = 12.0
+    let spacing: CGFloat = 20.0
+    let buttonTypes: [NSWindow.ButtonType] = [.closeButton, .miniaturizeButton, .zoomButton]
+
+    for (index, buttonType) in buttonTypes.enumerated() {
+      guard let button = standardWindowButton(buttonType),
+            let superview = button.superview else { continue }
+
+      let superviewHeight = superview.frame.height
+      let buttonHeight = button.frame.height
+
+      let centerFromTop = customTitleBarHeight / 2.0
+      let buttonTopFromTop = centerFromTop - buttonHeight / 2.0
+      let newY = superviewHeight - buttonTopFromTop - buttonHeight
+      let newX = xStart + CGFloat(index) * spacing
+
+      button.setFrameOrigin(NSPoint(x: newX, y: newY))
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Replace custom Flutter traffic light buttons with native macOS window buttons
- Red button / Cmd+W hides window to tray instead of quitting the app
- Clicking the Dock icon re-shows the hidden window
- Reposition native traffic lights to align with the 45px custom title bar
- Disable fullscreen (green button zooms/maximizes instead, matching original behavior)
- Add "Close Window" (Cmd+W) to the Window menu
- Hide "Minimize" behavior setting on macOS (not applicable with native buttons)

## Test plan
- [ ] Red traffic light button hides window, app stays in tray
- [ ] Cmd+W hides window, app stays in tray
- [ ] Clicking Dock icon re-shows hidden window
- [ ] Tray icon click toggles window visibility
- [ ] Tray "Quit" shows QuitDialog if instances are running, then exits
- [ ] Green button maximizes/restores (no fullscreen)
- [ ] Yellow button minimizes to Dock
- [ ] Traffic lights are vertically centered in the title bar
- [ ] Windows/Linux behavior is unchanged