### PR TITLE
macOS: route Cmd+Q through Flutter quit dialog

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -11,6 +11,7 @@ import 'package:animate_do/animate_do.dart';
 import 'package:awesome_extensions/awesome_extensions_dart.dart';
 import 'package:bonsoir/bonsoir.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:localization/localization.dart';
@@ -56,11 +57,16 @@ class _MainScreenState extends ConsumerState<MainScreen>
   Timer? runningInstancePingTimer;
   FocusNode node = FocusNode();
 
+  static const _lifecycleChannel = MethodChannel('app_lifecycle');
+
   @override
   void initState() {
     _init();
     windowManager.addListener(this);
     trayManager.addListener(this);
+    if (Platform.isMacOS) {
+      _lifecycleChannel.setMethodCallHandler(_handleLifecycleMethod);
+    }
     try {
       discovery = BonsoirDiscovery(type: adbMdns);
     } on Exception catch (e) {
@@ -70,8 +76,17 @@ class _MainScreenState extends ConsumerState<MainScreen>
     super.initState();
   }
 
+  Future<dynamic> _handleLifecycleMethod(MethodCall call) async {
+    if (call.method == 'quitRequested') {
+      await AppUtils.onAppCloseRequested(ref, context);
+    }
+  }
+
   @override
   void dispose() {
+    if (Platform.isMacOS) {
+      _lifecycleChannel.setMethodCallHandler(null);
+    }
     windowManager.removeListener(this);
     trayManager.removeListener(this);
     GoRouter.of(context)

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -7,6 +7,22 @@ class AppDelegate: FlutterAppDelegate {
     return false
   }
 
+  override func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+    guard let window = mainFlutterWindow,
+          let controller = window.contentViewController as? FlutterViewController else {
+      return .terminateNow
+    }
+
+    let channel = FlutterMethodChannel(name: "app_lifecycle", binaryMessenger: controller.engine.binaryMessenger)
+    channel.invokeMethod("quitRequested", arguments: nil)
+
+    if !window.isVisible {
+      window.makeKeyAndOrderFront(self)
+    }
+
+    return .terminateCancel
+  }
+
   override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return true
   }


### PR DESCRIPTION
## Summary
- Intercept `applicationShouldTerminate` in AppDelegate and send a `quitRequested` method call to Flutter via a platform channel
- Cmd+Q and Dock quit now go through `onAppCloseRequested`, showing the QuitDialog when there are active WiFi devices or scrcpy instances
- Falls back to `.terminateNow` if the Flutter engine is unavailable

## Test plan
- [ ] Cmd+Q with no active instances exits cleanly
- [ ] Cmd+Q with active WiFi devices or scrcpy instances shows QuitDialog
- [ ] Cmd+Q when window is hidden re-shows window before showing QuitDialog
- [ ] Right-click Dock > Quit behaves the same as Cmd+Q